### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = "clang-7 -pthread -lm -o main trab.c \n ./main"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # trabalho-ed-2
 Trabalho de ED 2
+
+[![Run on Repl.it](https://repl.it/badge/github/SergioVago/trabalho-ed-2)](https://repl.it/github/SergioVago/trabalho-ed-2)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Vagao/trabalho-ed-2).